### PR TITLE
Support deployment via dockerhub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,16 @@
 ## Reason for this PR:
 
-Closes #... 
+ -
 
 ## Changes in this PR:
 
-\[List all important changes\]
+ -
 
-- Change 1
-- Change 2
+## Checklist:
+
+Select whatever applies:
+ - [ ] Test written
+ - [ ] Code Properly Formatted 
+ - [ ] Documented
+ - [ ] Changelog updated
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next Release
+ - Add options for local deployment and deployment using the container images from dockerhub and fix ingress configuration in `deploy.sh` [#8](https://github.com/upbcuk/incentive-services/pull/8)
+
 ## [0.3.0] - 2021-01-12
 - Rename protocols to protocoldefinition and add cryptoprotocols module, include math and craco, add interfaces for cryptoprocools use [#6](https://github.com/upbcuk/incentive-services/pull/6)
 - Add local kubernetes support using KinD [#5](https://github.com/upbcuk/incentive-services/pull/5)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ We use KinD (Kubernetes in Docker) for the deployment:
 
 You can now access the api at [http://$NODE-IP/crediting/swagger-ui/index.html]() [http://$NODE_IP/issuing/swagger-ui/index.html](). The node ip can be queried with the command `kubectl get nodes -o wide`.
 
+If you want to deploy your local changes to a cluster, use `./deployment/deploy.sh -l`. This builds the container images from your local code instead of pulling the last release from dockerhub. 
+
 ---
 
 ## Changelog

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -23,6 +23,8 @@ LIGHTCYAN='\033[1;36m'
 WHITE='\033[1;37m'
 DEFAULT_COLOR=${LIGHTBLUE}
 
+LOCAL=false
+
 get_internal_node_ip() {
   kubectl get nodes -l "$1" -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}'
 }
@@ -46,13 +48,33 @@ msg() {
   echo -e "${DEFAULT_COLOR}$1${NOCOLOR}"
 }
 
+###############################################################################
+# Start of the actual script                                                  #
+###############################################################################
+
+usage() {
+  echo "Usage: $0 [-l]" 1>&2; exit 1;
+}
+
+while getopts "l" flag; do
+  case "${flag}" in
+    l)
+      LOCAL=true ;;
+    ?)
+      usage ;;
+  esac
+done
 
 ###############################################################################
 # Start of the actual script                                                  #
 ###############################################################################
 
 big-sep
-msg "| Starting local deployment 🧙‍"
+if [[ $LOCAL == true ]]; then
+  msg "| Starting local deployment 🧙‍"
+else
+  msg "| Starting deployment 🧙‍"
+fi
 big-sep
 
 # Create fresh kind cluster
@@ -60,29 +82,27 @@ header "Create fresh kind cluster"
 kind delete clusters kind-t2
 kind create cluster --name kind-t2 --config deployment/kind-t2-config.yaml
 
-# Build and load docker images of services
-header "Build and load images of services"
-set -e
-./gradlew clean build
-./gradlew ":credit:bootBuildImage"
-./gradlew ":issue:bootBuildImage"
-kind load docker-image upbcuk/incentive-service-issue --name kind-t2
-kind load docker-image upbcuk/incentive-service-credit --name kind-t2
-set +e
+if [[ $LOCAL == true ]]; then
+  # Build and load docker images of services
+  header "Build and load images of services"
+  set -e
+  ./gradlew clean build
+  ./gradlew ":credit:bootBuildImage"
+  ./gradlew ":issue:bootBuildImage"
+  kind load docker-image upbcuk/incentive-service-issue --name kind-t2
+  kind load docker-image upbcuk/incentive-service-credit --name kind-t2
+  set +e
 
-# Print available images
-header "Available container images:"
-docker exec -it kind-t2-control-plane crictl images
+  # Print available images
+  header "Available container images:"
+  docker exec -it kind-t2-control-plane crictl images
+fi
 
 # Deploy to kubernetes
 # Create ingress
 header "Create ingress"
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
-kubectl wait --namespace ingress-nginx \
-  --for=condition=ready pod \
-  --selector=app.kubernetes.io/component=controller \
-  --timeout=300s
 kubectl apply -f deployment/ingress.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
 
 # Deploy services
 header "Deploy services"
@@ -93,4 +113,5 @@ echo ""
 big-sep
 msg "| Done! 🥳"
 msg "| Node-ip: $(get_internal_node_ip "cuk.cs.upb.de/kind-control-plane")"
+msg "| It may take some time until all services are reachable"
 big-sep


### PR DESCRIPTION
## Reason for this PR:
 - The deployment script only supports locally built container images. We want to use the deployed images from dockerhub.

## Changes in this PR:
 - Update `deploy.sh` script to support container images from dockerhub
 - Add instructions to readme
 - Fix ingress error in the deployment script