### PR TITLE
Update old issue service config to suppport kubernetes ingress.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Next Release
+- Fix wrong issue service configuration bug [#9](https://github.com/upbcuk/incentive-services/pull/9)
+
 ## [0.3.0] - 2021-01-12
 - Rename protocols to protocoldefinition and add cryptoprotocols module, include math and craco, add interfaces for cryptoprocools use [#6](https://github.com/upbcuk/incentive-services/pull/6)
 - Add local kubernetes support using KinD [#5](https://github.com/upbcuk/incentive-services/pull/5)

--- a/issue/src/main/resources/application-dev.properties
+++ b/issue/src/main/resources/application-dev.properties
@@ -1,1 +1,1 @@
-t2.server.gateway=/
+server.port=8001

--- a/issue/src/main/resources/application-production.properties
+++ b/issue/src/main/resources/application-production.properties
@@ -1,1 +1,2 @@
-t2.server.gateway=/issuing-service/
+server.servlet.context-path=/issuing
+server.port=8000


### PR DESCRIPTION
## Reason for this PR:

 - The configuration of the issue service was outdated and hence not compatible with the Kubernetes ingress configuration.

## Changes in this PR:

 - Set context of issue service in production to `/issuing` 
 - Set ports for `./gradlew bootRun` to 8001 and 8002